### PR TITLE
更新：Arceos在飞腾派上运行，USB协议栈的描述表

### DIFF
--- a/src/ch0-0.md
+++ b/src/ch0-0.md
@@ -6,7 +6,7 @@ ArceOS的整体架构如下所示：
 
 ArceOS 是一个开源的、组件化的Unikernel。以组合组件库的方式构建系统。使用Rust开发。
 
-具有一下特点和功能:
+具有以下特点和功能:
 
 - CPU架构: x86_64, riscv64, aarch64
 - 运行平台: QEMU pc-q35 (x86_64), virt (riscv64/aarch64)

--- a/src/ch1-1.md
+++ b/src/ch1-1.md
@@ -1,48 +1,90 @@
 # 飞腾派运行ArceOS
 
-1. 硬件准备：
-   * 飞腾派板子
-   ![structure](assert/飞腾派图片.jpg)
+## 1 硬件准备
 
-   * 一张SD卡，放飞腾派官方镜像(uboot)
-   地址<https://pan.baidu.com/s/1pStiyqohrB3SxHAFFk8R6Q?pwd=dzdv#list/path=%2F%E9%A3%9E%E8%85%BE%E6%B4%BEv2.1%E8%B5%84%E6%96%99%E5%8C%85%EF%BC%88%E8%B5%84%E6%96%99%E5%8C%85%E5%A4%AA%E5%A4%A7%EF%BC%8C%E5%BB%BA%E8%AE%AE%E6%8C%91%E9%80%89%E4%B8%8B%E8%BD%BD%EF%BC%89%2F5-%E7%B3%BB%E7%BB%9F%E9%95%9C%E5%83%8F%2F1-Ubuntu_xfce%2F4GB%2F%E4%B9%8B%E5%89%8D%E7%89%88%E6%9C%AC>(在系统镜像>1-Ubuntu...>4GB>之前版本中的sd_boot_xfce_4GB_230726.img.tar.gz)
-
-   * 读卡器(将SD卡和电脑连接在一起)
-
-   * 烧录工具(Win32DiskImager2.0.1.8.exe)
-   地址<https://pan.baidu.com/s/1pStiyqohrB3SxHAFFk8R6Q?pwd=dzdv#list/path=%2F%E9%A3%9E%E8%85%BE%E6%B4%BEv2.1%E8%B5%84%E6%96%99%E5%8C%85%EF%BC%88%E8%B5%84%E6%96%99%E5%8C%85%E5%A4%AA%E5%A4%A7%EF%BC%8C%E5%BB%BA%E8%AE%AE%E6%8C%91%E9%80%89%E4%B8%8B%E8%BD%BD%EF%BC%89%2F9-%E5%B7%A5%E5%85%B7%E5%8C%85&parentPath=%2F>(在飞腾派v2.1资料包（资料包太...>9-工具包中的Win32DiskImager2.0.1.8.exe)
-
-   * USB转TTL串口线(将飞腾派和电脑连接在一起，方便收发debug信息和文件)
-
-   * ArceOS代码地址：<https://github.com/arceos-usb/arceos_experiment/tree/usb-camera-base>（注意分支）
+* 飞腾派板子
+   <img src="assert/飞腾派图片.jpg" alt="structure" style="zoom: 33%;" />
+   
+* 一张SD卡和一个读卡器，用于安装飞腾派官方镜像
   
-     `git clone https://github.com/arceos-usb/arceos_experiment.git
+* USB转TTL转换器和串口线，用于将飞腾派串口和电脑USB接口连接在一起，方便收发调试信息和文件
+  
+## 2 烧录镜像
 
-     编译镜像命令：`make A=apps/usb-hid PLATFORM=aarch64-phytium-pi LOG=trace`
+- 如果你不只是在飞腾派运行Arceos，还需要在飞腾派上运行Ubuntu，则需要下载如下镜像：
 
-     生成的bin文件在apps/usb-hid目录下
+  [Ubuntu镜像地址](https://pan.baidu.com/s/1pStiyqohrB3SxHAFFk8R6Q?pwd=dzdv#list/path=%2F%E9%A3%9E%E8%85%BE%E6%B4%BEv2.1%E8%B5%84%E6%96%99%E5%8C%85%EF%BC%88%E8%B5%84%E6%96%99%E5%8C%85%E5%A4%AA%E5%A4%A7%EF%BC%8C%E5%BB%BA%E8%AE%AE%E6%8C%91%E9%80%89%E4%B8%8B%E8%BD%BD%EF%BC%89%2F5-%E7%B3%BB%E7%BB%9F%E9%95%9C%E5%83%8F%2F1-Ubuntu_xfce%2F4GB%2F%E4%B9%8B%E5%89%8D%E7%89%88%E6%9C%AC)：(在系统镜像>1-Ubuntu...>4GB>之前版本中的sd_boot_xfce_4GB_230726.img.tar.gz)
 
-2. 飞腾派上电启动，把烧录了uboot的SD卡插到飞腾派上，把装有arceos的镜像文件插在飞腾派的usb插槽上(靠近风扇的蓝色口的)，用串口把飞腾派与电脑相连接，启动电脑上的远程连接软件，如MobaXterm，波特率设置为115200
+- 需要注意的是烧录Ubuntu镜像需要至少16G的SD卡，如果你的SD卡不足16G，或者只是想运行Arceos，则无需下载Ubuntu镜像，此时只需下载uboot镜像即可。由于uboot镜像占用的空间只有4MB左右，可以认为对SD卡的容量没有要求：
 
-   串口接法：接8、10、12号引脚位置，如图所示（8号代表TX，接RX；10号代表RX，接TX；12号接地线）
+  [uboot镜像地址](https://www.iceasy.com/cloud/Phytium)：（在4-系统源码>4-系统源码>uboot固件>fip-all-4GB-250321.bin）
+  
+- 如果你电脑主机上运行的是Windows，需要下载烧录工具(Win32DiskImager2.0.1.8.exe)
+  
+  [烧录工具的地址](https://pan.baidu.com/s/1pStiyqohrB3SxHAFFk8R6Q?pwd=dzdv#list/path=%2F%E9%A3%9E%E8%85%BE%E6%B4%BEv2.1%E8%B5%84%E6%96%99%E5%8C%85%EF%BC%88%E8%B5%84%E6%96%99%E5%8C%85%E5%A4%AA%E5%A4%A7%EF%BC%8C%E5%BB%BA%E8%AE%AE%E6%8C%91%E9%80%89%E4%B8%8B%E8%BD%BD%EF%BC%89%2F9-%E5%B7%A5%E5%85%B7%E5%8C%85&parentPath=%2F)：(在飞腾派v2.1资料包（资料包太...>9-工具包中的Win32DiskImager2.0.1.8.exe)
+  
+- 如果你电脑主机上运行的是Linux，直接使用`dd`命令即可
+  
 
-   ![structure](assert/飞腾派串口连接示意图.jpg)
+## 3 编译Arceos
+
+ArceOS代码地址：<https://github.com/arceos-usb/arceos_experiment/tree/usb-camera-base>（注意分支）
+
+```bash
+git clone https://github.com/arceos-usb/arceos_experiment.git	# 下载源码
+cd arceos_experiment
+make A=apps/usb-hid PLATFORM=aarch64-phytium-pi LOG=trace	# 编译镜像，生成的bin文件在apps/usb-hid目录下
+```
+
+## 4 运行Arceos
+
+注：uboot支持多种方法启动Arceos，如从U盘启动、从SD卡启动、从局域网启动。如果你是在调试或开发Arceos，建议从局域网启动，这样可以避免频繁插拔SD卡或U盘。
+
+1. 飞腾派上电启动，把烧录了uboot的SD卡插到飞腾派上。如果选择了从U盘启动，还需要把装有arceos的镜像文件的U盘插在飞腾派的usb插槽上(靠近风扇的蓝色口的)。用USB转TTL转换器把飞腾派与电脑相连接，启动电脑上的远程连接软件（如果是Windows系统，可以使用MobaXterm；如果是Linux系统，可以使用minicom命令），波特率设置为115200
+
+2. 串口接法：接8、10、12号引脚位置，如图所示（8号代表TX，接RX；10号代表RX，接TX；12号接地线）
+
+<img src="assert/飞腾派串口连接示意图.jpg" alt="structure" style="zoom:33%;" />
 
 3. 在uboot倒计时结束前按任意键进入手动引导
-   * 输入`usb start` ,启用USB驱动来识别插入的USB设备（读U盘中的arceos）
+   * 如果是从U盘启动
    
-     ![structure](assert/飞腾派启动ArceOS-1.png)
+     输入`usb start` ,启用USB驱动来识别插入的USB设备（读U盘中的arceos）
    
-   * 输入`fatload usb 0 0x90100000 usb-hid_aarch64-phytium-pi.bin`，从插入的USB设备上下载ArceOS镜像
+     <img src="assert/飞腾派启动ArceOS-1.png" alt="structure" style="zoom: 80%;" />
 
-     ![structure](assert/飞腾派启动ArceOS-2.png)
+     输入`fatload usb 0 0x90100000 usb-hid_aarch64-phytium-pi.bin`，从插入的USB设备上下载ArceOS镜像
 
+     <img src="assert/飞腾派启动ArceOS-2.png" alt="structure" style="zoom: 50%;" />
+
+   * 如果是从局域网启动
+
+     在电脑端，要安装tftp服务
+
+     ```bash
+     sudo apt install tftpd-hpa
+     vim /etc/default/tfptpd-hpa	# 配置tftp服务
+     # 需要把生成的Arceos镜像复制进配置文件所指定的tftp目录里
+     ```
+   
+     在飞腾派端，使用tftpboot命令加载Arceos镜像
+   
+     ```bash
+      echo $ipaddr	# 检查ip地址满足局域网要求
+      setenv ipaddr x.x.x.x	# 如不满足，需先设置ip地址
+      setenv serverip x.x.x.x
+      tftpboot 0x90100000 xxx.bin
+      dcache flush
+     ```
+   
+     
+   
    * 输入`go 0x90100000`加载ArceOS镜像
-
-     ![structure](assert/飞腾派启动ArceOS-3.png)
-
+   
+     <img src="assert/飞腾派启动ArceOS-3.png" alt="structure" style="zoom: 80%;" />
+   
      （这里是没有添加LOG=debug）
-
+   
    * 如果是在apps/cli目录下编译的出来的arceos镜像，便可以看到ArceOS启动成功，进入到了shell界面
 
 更直观方便的实验方法，在linux终端里面测试USB返回的debug信息
@@ -76,7 +118,7 @@
 
 ```
 make A=apps/uvc PLATFORM=aarch64-phytium-pi LOG=trace chainboot
-```  
+```
 
 前面的make是将整个arceos内核与USB驱动给编译好，  
 后面的chainboot用来执行一个arceos_experiment目录中的一个脚本文件，将编译好的内核文件通过SD卡中的Uboot加载到飞腾派上

--- a/src/ch1-3.md
+++ b/src/ch1-3.md
@@ -118,6 +118,14 @@
       
       ![tick-tock-machine](assert/figures/tick-tock-machine.png)
 
+用一个表来描述Arceos的USB协议栈，如下表所示：
+
+| 层级       | 功能                                                         | 对应的目录                                                   |
+| ---------- | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| USB驱动层  | HID, UVC, CDC等设备驱动的实现                                | usb/drivers<br>usb/transfer<br>usb/operation<br>usb/universal_drivers<br>usb/urb.rs<br>glue/ucb.rs |
+| 设备抽象层 | 对不同的USB控制器抽象出统一的接口，对上层驱动提供统一的数据抽象 | abstractions/<br>usb/descriptors<br>glue/driver_independent_device_instance.rs |
+| 主机驱动层 | 是USB主机控制器的驱动                                        | host/                                                        |
+
 ## 代码结构
 
 ```log


### PR DESCRIPTION
更新src/ch1-1.md，添加：烧录uboot的方法，Linux下操控飞腾派的方法，从局域网启动飞腾派的方法；
更新src/ch1-3.md，添加：对USB协议栈的描述表